### PR TITLE
Add multi-file upload support

### DIFF
--- a/src/components/AnnouncementList.jsx
+++ b/src/components/AnnouncementList.jsx
@@ -108,7 +108,12 @@ export default function AnnouncementList() {
                       {item.attachments && item.attachments.length > 0 && (
                         <div className="mt-2 flex flex-wrap gap-2">
                           {item.attachments.map(att => (
-                            <a key={att.id} href={getPublicUrl(att.stored_file_path)} target="_blank" className="text-blue-600 underline text-xs">
+                            <a
+                              key={att.id}
+                              href={att.public_url || getPublicUrl(att.stored_file_path)}
+                              target="_blank"
+                              className="text-blue-600 underline text-xs"
+                            >
                               {att.file_name}
                             </a>
                           ))}

--- a/src/components/AttachmentUploader.jsx
+++ b/src/components/AttachmentUploader.jsx
@@ -11,20 +11,26 @@ export default function AttachmentUploader({ files = [], setFiles, disabled }) {
     e.target.value = ''
   }
 
+  const handleDrop = (e) => {
+    e.preventDefault()
+    if (disabled) return
+    const dropped = Array.from(e.dataTransfer.files || [])
+    if (dropped.length > 0) {
+      setFiles([...files, ...dropped])
+    }
+  }
+
   const handleRemove = (idx) => {
     setFiles(files.filter((_, i) => i !== idx))
   }
 
   return (
-    <div>
-      <button
-        type="button"
-        onClick={() => fileInputRef.current?.click()}
-        disabled={disabled}
-        className="px-3 py-1.5 bg-indigo-600 text-white rounded hover:bg-indigo-700 text-sm"
-      >
-        選擇檔案
-      </button>
+    <div
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={handleDrop}
+      className={`border-2 border-dashed rounded-lg p-4 text-center ${disabled ? 'bg-gray-100' : 'hover:border-indigo-400 cursor-pointer'}`}
+      onClick={() => !disabled && fileInputRef.current?.click()}
+    >
       <input
         type="file"
         multiple
@@ -33,20 +39,24 @@ export default function AttachmentUploader({ files = [], setFiles, disabled }) {
         className="hidden"
         disabled={disabled}
       />
-      <ul className="mt-2 space-y-1">
-        {files.map((f, idx) => (
-          <li key={idx} className="flex justify-between items-center bg-gray-100 rounded px-2 py-1 text-sm">
-            <span className="break-all">{f.name}</span>
-            <button
-              type="button"
-              onClick={() => handleRemove(idx)}
-              className="text-red-500 text-xs ml-2"
-            >
-              移除
-            </button>
-          </li>
-        ))}
-      </ul>
+      {files.length === 0 ? (
+        <p className="text-sm text-gray-500">拖曳檔案至此或點擊選擇</p>
+      ) : (
+        <ul className="space-y-1">
+          {files.map((f, idx) => (
+            <li key={idx} className="flex justify-between items-center bg-gray-100 rounded px-2 py-1 text-sm">
+              <span className="break-all">{f.name}</span>
+              <button
+                type="button"
+                onClick={() => handleRemove(idx)}
+                className="text-red-500 text-xs ml-2"
+              >
+                移除
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   )
 }

--- a/src/components/CreateAnnouncementModal.jsx
+++ b/src/components/CreateAnnouncementModal.jsx
@@ -483,10 +483,14 @@ export default function CreateAnnouncementModal({ isOpen, onClose, refreshAnnoun
                     .from('attachments')
                     .upload(path, file);
                 if (upErr) throw upErr;
+                const { data: urlData } = supabase.storage
+                    .from('attachments')
+                    .getPublicUrl(path);
                 const { error: insErr } = await supabase.from('attachments').insert({
                     announcement_id: announcementId,
                     file_name: file.name,
                     stored_file_path: path,
+                    public_url: urlData.publicUrl,
                     file_size: file.size,
                     mime_type: file.type,
                 });

--- a/src/components/UpdateAnnouncementModal.jsx
+++ b/src/components/UpdateAnnouncementModal.jsx
@@ -144,10 +144,14 @@ export default function UpdateAnnouncementModal({ isOpen, onClose, announcement,
           .from('attachments')
           .upload(path, file)
         if (upErr) throw upErr
+        const { data: urlData } = supabase.storage
+          .from('attachments')
+          .getPublicUrl(path)
         const { error: insErr } = await supabase.from('attachments').insert({
           announcement_id: updated.id,
           file_name: file.name,
           stored_file_path: path,
+          public_url: urlData.publicUrl,
           file_size: file.size,
           mime_type: file.type
         })

--- a/src/sql/supabase_schema.sql
+++ b/src/sql/supabase_schema.sql
@@ -17,6 +17,15 @@ DO $$ BEGIN
 END $$;
 
 -- ===============================
+-- 0️⃣ 建立公開 Storage Bucket
+-- ===============================
+SELECT
+  CASE
+    WHEN NOT EXISTS (SELECT 1 FROM storage.buckets WHERE name = 'attachments')
+    THEN storage.create_bucket('attachments', true)
+  END;
+
+-- ===============================
 -- 1️⃣ 建立 profiles 表
 -- ===============================
 CREATE TABLE IF NOT EXISTS public.profiles (
@@ -54,15 +63,13 @@ CREATE TABLE IF NOT EXISTS public.announcements (
   tags TEXT[]
 );
 
--- ===============================
--- 3️⃣ 建立 attachments 表
--- ===============================
 CREATE TABLE IF NOT EXISTS public.attachments (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
   announcement_id UUID REFERENCES public.announcements(id) ON DELETE CASCADE,
   file_name VARCHAR(255) NOT NULL,
   stored_file_path VARCHAR(255) NOT NULL,
   uploaded_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  public_url TEXT,
   file_size INT,
   mime_type VARCHAR(255)
 );


### PR DESCRIPTION
## Summary
- create `attachments` storage bucket in schema
- add `public_url` column to attachments table
- store public URLs when uploading attachments
- support drag-and-drop multi-file upload
- show attachment links from stored URLs

## Testing
- `npm run build` *(fails: Failed to fetch font and missing module)*

------
https://chatgpt.com/codex/tasks/task_e_688accb42348832389c5982c7b735e95