### PR TITLE
Fix old auth helpers usage

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -1,9 +1,22 @@
 import { NextResponse } from 'next/server';
-import { createMiddlewareClient } from '@supabase/auth-helpers-nextjs';
+import { createServerClient } from '@supabase/ssr';
 
 export async function middleware(request) {
   const res = NextResponse.next();
-  const supabase = createMiddlewareClient({ req: request, res });
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    {
+      cookies: {
+        getAll: () => request.cookies.getAll(),
+        setAll: (cookies) => {
+          cookies.forEach(({ name, value, options }) => {
+            res.cookies.set({ name, value, ...options });
+          });
+        },
+      },
+    }
+  );
   
   // 刷新 session（如果過期的話）
   const { data: { session } } = await supabase.auth.getSession();

--- a/src/app/auth/callback/page.jsx
+++ b/src/app/auth/callback/page.jsx
@@ -2,13 +2,16 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+import { createBrowserClient } from '@supabase/ssr';
 
 export default function AuthCallback() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [status, setStatus] = useState('處理中...');
-  const supabase = createClientComponentClient();
+  const supabase = createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  );
 
   useEffect(() => {
     const handleAuthCallback = async () => {

--- a/src/app/auth/callback/route.js
+++ b/src/app/auth/callback/route.js
@@ -1,4 +1,4 @@
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
 
@@ -7,7 +7,21 @@ export async function GET(request) {
   const code = requestUrl.searchParams.get('code')
 
   if (code) {
-    const supabase = createRouteHandlerClient({ cookies })
+    const cookieStore = cookies()
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+      {
+        cookies: {
+          getAll: () => cookieStore.getAll(),
+          setAll: (newCookies) => {
+            newCookies.forEach(({ name, value, options }) => {
+              cookieStore.set({ name, value, ...options })
+            })
+          }
+        }
+      }
+    )
     
     try {
       const { data, error } = await supabase.auth.exchangeCodeForSession(code)


### PR DESCRIPTION
## Summary
- use `@supabase/ssr` for auth logic and remove old helper imports
- update auth callback page and route to use browser/server clients
- update middleware to create server client for session checks

## Testing
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_688b292667a083239bfef89868ac5116