### PR TITLE
新增偏好表單與下拉選單

### DIFF
--- a/src/components/PreferenceForm.jsx
+++ b/src/components/PreferenceForm.jsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState, useEffect } from 'react';
+import Button from '@/components/ui/Button';
+
+const categoryOptions = [
+  { value: '', label: '不限' },
+  { value: 'A', label: 'A: 縣市政府' },
+  { value: 'B', label: 'B: 其他公家機關' },
+  { value: 'C', label: 'C: 宗親會/指定身分' },
+  { value: 'D', label: 'D: 其他民間單位' },
+  { value: 'E', label: 'E: 得獎名單' }
+];
+
+export default function PreferenceForm({ onSubmit, initialData = {} }) {
+  const [form, setForm] = useState({
+    preferredCategory: '',
+    note: ''
+  });
+
+  useEffect(() => {
+    setForm(prev => ({ ...prev, ...initialData }));
+  }, [initialData]);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSubmit(form);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 bg-white shadow p-6 rounded-lg max-w-2xl w-full">
+      <div className="grid gap-4">
+        <div>
+          <label className="block text-sm font-medium mb-1">偏好獎學金分類</label>
+          <select
+            name="preferredCategory"
+            value={form.preferredCategory}
+            onChange={handleChange}
+            className="w-full border rounded px-3 py-2"
+          >
+            {categoryOptions.map(opt => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">其他需求或備註</label>
+          <textarea
+            name="note"
+            value={form.note}
+            onChange={handleChange}
+            className="w-full border rounded px-3 py-2"
+            rows={3}
+          />
+        </div>
+      </div>
+      <div className="text-center">
+        <Button type="submit" className="mt-4">開始對話</Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/StudentInfoForm.jsx
+++ b/src/components/StudentInfoForm.jsx
@@ -3,6 +3,18 @@
 import { useState, useEffect } from 'react'
 import Button from '@/components/ui/Button'
 
+// 年級選項
+const gradeOptions = ['1', '2', '3', '4', '5', '6', '7', '8', '9']
+// 系所選項（節錄部分系所供示例使用）
+const departmentOptions = [
+  '教育學系',
+  '國文學系',
+  '英語學系',
+  '數學系',
+  '資訊工程學系',
+  '其他'
+]
+
 const familyOptions = [
   '低收',
   '中低收',
@@ -62,7 +74,17 @@ export default function StudentInfoForm({ onSubmit, initialData = {} }) {
         </div>
         <div>
           <label className="block text-sm font-medium mb-1">系所名稱</label>
-          <input name="department" value={form.department} onChange={handleChange} className="w-full border rounded px-3 py-2" />
+          <select
+            name="department"
+            value={form.department}
+            onChange={handleChange}
+            className="w-full border rounded px-3 py-2"
+          >
+            <option value="">請選擇</option>
+            {departmentOptions.map(opt => (
+              <option key={opt} value={opt}>{opt}</option>
+            ))}
+          </select>
         </div>
         <div>
           <label className="block text-sm font-medium mb-1">新生</label>
@@ -73,7 +95,17 @@ export default function StudentInfoForm({ onSubmit, initialData = {} }) {
         </div>
         <div>
           <label className="block text-sm font-medium mb-1">年級</label>
-          <input type="number" min="1" max="9" name="grade" value={form.grade} onChange={handleChange} className="w-full border rounded px-3 py-2" />
+          <select
+            name="grade"
+            value={form.grade}
+            onChange={handleChange}
+            className="w-full border rounded px-3 py-2"
+          >
+            <option value="">請選擇</option>
+            {gradeOptions.map(opt => (
+              <option key={opt} value={opt}>{opt}</option>
+            ))}
+          </select>
         </div>
         <div>
           <label className="block text-sm font-medium mb-1">家境</label>


### PR DESCRIPTION
## Summary
- 新增 `PreferenceForm` 讓使用者填寫獎學金偏好
- `StudentInfoForm` 的年級與系所改為下拉選單
- `ChatPage` 增加偏好表單並依據填寫內容調整 prompt

## Testing
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_688c1eb3196c8323bfc7cf3a9d475687