### PR TITLE
修正表單初始化的循環錯誤

### DIFF
--- a/src/app/ai-assistant/chat/page.jsx
+++ b/src/app/ai-assistant/chat/page.jsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useMemo } from 'react'
 import { useAuth } from '@/hooks/useAuth'
 import { GoogleGenAI } from '@google/genai'
 import StudentInfoForm from '@/components/StudentInfoForm'
@@ -90,13 +90,15 @@ export default function ChatPage() {
     }
   }
 
+  const userInfo = useMemo(() => ({
+    department: user?.user_metadata?.department || '',
+    grade: user?.user_metadata?.year || ''
+  }), [user])
+
   if (phase === 'info') {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gray-50 py-8">
-        <StudentInfoForm onSubmit={handleInfoSubmit} initialData={{
-          department: user?.user_metadata?.department || '',
-          grade: user?.user_metadata?.year || ''
-        }} />
+        <StudentInfoForm onSubmit={handleInfoSubmit} initialData={userInfo} />
       </div>
     )
   }

--- a/src/components/PreferenceForm.jsx
+++ b/src/components/PreferenceForm.jsx
@@ -12,14 +12,17 @@ const categoryOptions = [
   { value: 'E', label: 'E: 得獎名單' }
 ];
 
-export default function PreferenceForm({ onSubmit, initialData = {} }) {
+export default function PreferenceForm({ onSubmit, initialData }) {
   const [form, setForm] = useState({
     preferredCategory: '',
     note: ''
   });
 
+  // 如果有提供初始值，僅在初次載入時套用
   useEffect(() => {
-    setForm(prev => ({ ...prev, ...initialData }));
+    if (initialData) {
+      setForm(prev => ({ ...prev, ...initialData }));
+    }
   }, [initialData]);
 
   const handleChange = (e) => {

--- a/src/components/StudentInfoForm.jsx
+++ b/src/components/StudentInfoForm.jsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react'
 import Button from '@/components/ui/Button'
 
 // 年級選項
-const gradeOptions = ['1', '2', '3', '4', '5', '6', '7', '8', '9']
+const gradeOptions = ['大一', '大二', '大三', '大四', '碩', '博']
 // 系所選項（節錄部分系所供示例使用）
 const departmentOptions = [
   '教育學系',
@@ -24,10 +24,9 @@ const familyOptions = [
   '無以上資料但家境清寒'
 ]
 
-export default function StudentInfoForm({ onSubmit, initialData = {} }) {
+export default function StudentInfoForm({ onSubmit, initialData }) {
   const [form, setForm] = useState({
     educationLevel: '',
-    college: '',
     department: '',
     freshman: '否',
     grade: '',
@@ -42,8 +41,11 @@ export default function StudentInfoForm({ onSubmit, initialData = {} }) {
   })
 
   // 載入初始資料（若提供）
+  // 若有初始資料，僅於初次載入時套用
   useEffect(() => {
-    setForm(prev => ({ ...prev, ...initialData }))
+    if (initialData) {
+      setForm(prev => ({ ...prev, ...initialData }))
+    }
   }, [initialData])
 
   const handleChange = (e) => {
@@ -67,10 +69,6 @@ export default function StudentInfoForm({ onSubmit, initialData = {} }) {
             <option value="碩班">碩班</option>
             <option value="博班">博班</option>
           </select>
-        </div>
-        <div>
-          <label className="block text-sm font-medium mb-1">就讀學院</label>
-          <input name="college" value={form.college} onChange={handleChange} className="w-full border rounded px-3 py-2" />
         </div>
         <div>
           <label className="block text-sm font-medium mb-1">系所名稱</label>


### PR DESCRIPTION
## Summary
- 修正 `PreferenceForm` 與 `StudentInfoForm` 的 `useEffect` 依賴問題
- 移除 `StudentInfoForm` 中的就讀學院欄位並調整年級選項
- 於 `chat` 頁面使用 `useMemo` 穩定初始資料

## Testing
- `npm run build` *(failed: Failed to fetch font `Noto Sans TC`)*

------
https://chatgpt.com/codex/tasks/task_e_688c22eba6bc83239ef84ce76408d0ab