### PR TITLE
調整首頁樣式與列表排序過渡

### DIFF
--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -5,30 +5,33 @@ import AnnouncementList from "@/components/AnnouncementList";
 
 
 export default function Home() {
-	const { isAuthenticated } = useAuth();
+        const { isAuthenticated } = useAuth();
 
-	return (
-		<div className="font-sans min-h-screen">
-			<div className="relative w-full h-48 md:h-64 xl:h-80 overflow-hidden">
-				<Image
-					src="/banner.jpg"
-					alt="NCUE Banner"
-					fill
-					priority
-					className="object-cover xl:object-contain object-center transition-all duration-300"
-				/>
-			</div>
-			<main className="flex flex-col gap-8 items-center sm:items-start max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-				<div className="text-center sm:text-left">
-					<h2 className="text-3xl font-bold mb-4" style={{ color: 'var(--primary)' }}>
-						歡迎來到 彰師校外獎學金資訊平台
-					</h2>
-					<p className="text-lg mb-8" style={{ color: 'var(--text-muted)' }}>
-						您可以在這裡獲取所有校外獎學金的資訊，並且使用 AI 問答助理解答您的問題。
-					</p>
-				</div>
-				<AnnouncementList />
-			</main>
-		</div>
-	);
+        return (
+                // 參考管理頁樣式，使用白色背景與全寬設定
+                <div className="w-full bg-white font-sans min-h-screen">
+                        {/* Banner 圖片高度自動，寬度 100% */}
+                        <div className="w-full">
+                                <Image
+                                        src="/banner.jpg"
+                                        alt="NCUE Banner"
+                                        width={4000}
+                                        height={862}
+                                        priority
+                                        className="w-full h-auto object-cover"
+                                />
+                        </div>
+                        <main className="flex flex-col gap-8 items-center sm:items-start max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+                                <div className="text-center sm:text-left">
+                                        <h2 className="text-3xl font-bold mb-4" style={{ color: 'var(--primary)' }}>
+                                                歡迎來到 彰師校外獎學金資訊平台
+                                        </h2>
+                                        <p className="text-lg mb-8" style={{ color: 'var(--text-muted)' }}>
+                                                您可以在這裡獲取所有校外獎學金的資訊，並且使用 AI 問答助理解答您的問題。
+                                        </p>
+                                </div>
+                                <AnnouncementList />
+                        </main>
+                </div>
+        );
 }

--- a/src/components/AnnouncementList.jsx
+++ b/src/components/AnnouncementList.jsx
@@ -172,14 +172,13 @@ export default function AnnouncementList() {
             <div className="bg-white rounded-xl shadow-lg overflow-hidden">
                 {/* Desktop Table */}
                 <div className="hidden md:block relative">
-                    {sortLoading && (
-                        <div className="absolute inset-0 bg-white bg-opacity-70 z-10 flex items-center justify-center">
-                            <div className="flex items-center gap-2 text-slate-600">
-                                <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-indigo-600"></div>
-                                <span>排序中...</span>
-                            </div>
+                    {/* 排序時顯示覆蓋層，避免列表閃爍 */}
+                    <div className={`absolute inset-0 bg-white bg-opacity-70 z-10 flex items-center justify-center transition-opacity duration-300 ${sortLoading ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}>
+                        <div className="flex items-center gap-2 text-slate-600">
+                            <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-indigo-600"></div>
+                            <span>排序中...</span>
                         </div>
-                    )}
+                    </div>
                     <table className="w-full">
                         <thead className="bg-gray-50">
                             <tr>
@@ -222,14 +221,13 @@ export default function AnnouncementList() {
 
                 {/* Mobile Card List */}
                 <div className="md:hidden divide-y divide-gray-200 relative">
-                    {sortLoading && (
-                        <div className="absolute inset-0 bg-white bg-opacity-70 z-10 flex items-center justify-center">
-                            <div className="flex items-center gap-2 text-slate-600">
-                                <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-indigo-600"></div>
-                                <span>排序中...</span>
-                            </div>
+                    {/* 排序時顯示覆蓋層，避免列表閃爍 */}
+                    <div className={`absolute inset-0 bg-white bg-opacity-70 z-10 flex items-center justify-center transition-opacity duration-300 ${sortLoading ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}>
+                        <div className="flex items-center gap-2 text-slate-600">
+                            <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-indigo-600"></div>
+                            <span>排序中...</span>
                         </div>
-                    )}
+                    </div>
                     {loading ? (
                         <div className="p-10 text-center text-gray-500">載入中...</div>
                     ) : announcements.map(item => (


### PR DESCRIPTION
## Summary
- 調整首頁佈局，套用與管理頁一致的白色背景與全寬設定，並將 Banner 圖片改為高度自動、寬度 100%
- 公告列表在排序時加入漸變覆蓋層，避免項目重新排序時產生閃爍

## Testing
- `npm test` (無 test 腳本)


------
https://chatgpt.com/codex/tasks/task_e_688f58b295248323b700032a8c3c9c5f