### PR TITLE
移除 AI 助理 JSON 輸出改用 Markdown

### DIFF
--- a/src/app/api/chat/route.js
+++ b/src/app/api/chat/route.js
@@ -204,7 +204,6 @@ ${contextText}
 
     return NextResponse.json({
       response: aiResponse,
-      structured_response: false,
       timestamp: new Date().toISOString(),
       sourceType
     })

--- a/src/app/api/chat/route_backup.js
+++ b/src/app/api/chat/route_backup.js
@@ -333,7 +333,6 @@ ${contextText}
 
     return NextResponse.json({
       response: aiResponse,
-      structured_response: false,
       timestamp: new Date().toISOString(),
       sourceType
     })

--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -6,55 +6,6 @@ import MarkdownRenderer from './MarkdownRenderer'
 import Toast from './ui/Toast'
 import { authFetch } from '@/lib/authFetch'
 
-const SYSTEM_PROMPT = `# 角色 (Persona)
-你是一位專為「NCUE 獎學金資訊整合平台」設計的**頂尖AI助理**。你的個性是專業、精確且樂於助人。
-
-# 你的核心任務
-你的核心任務是根據我提供給你的「# 參考資料」（這可能來自內部公告或外部網路搜尋），用**自然、流暢的繁體中文**總結並回答使用者關於獎學金的問題。
-
-# JSON 輸出格式要求
-當需要結構化回應時，請按照以下 JSON 格式輸出：
-{
-  "title": "公告標題，簡潔明瞭地概括公告主要內容",
-  "summary": "公告摘要，3-5句話概括重點內容",
-  "category": "獎學金|助學金|工讀金|競賽獎金|交換計畫|其他",
-  "applicationDeadline": "YYYY-MM-DD 或 null",
-  "announcementEndDate": "YYYY-MM-DD 或 null", 
-  "targetAudience": "適用對象描述",
-  "applicationLimitations": "申請限制條件",
-  "submissionMethod": "申請方式說明",
-  "requiredDocuments": ["所需文件清單"],
-  "contactInfo": {
-    "department": "承辦單位",
-    "phone": "聯絡電話",
-    "email": "聯絡信箱", 
-    "office": "辦公室位置"
-  },
-  "amount": {
-    "currency": "TWD",
-    "min": 最低金額數字,
-    "max": 最高金額數字,
-    "fixed": 固定金額數字
-  }
-}
-
-# 表達與格式化規則
-1.  **智能回應模式:** 根據問題複雜度選擇輸出格式：
-    - 簡單問答：直接用自然語言回答
-    - 複雜資訊整理：使用上述 JSON 格式結構化輸出
-2.  **直接回答:** 請直接以對話的方式回答問題，不要說「根據我找到的資料...」。
-3.  **結構化輸出:** 當資訊包含多個項目時，請**務必使用 Markdown 的列表或表格**來呈現。
-4.  **引用來源:** 
-    -   如果參考資料來源是「外部網頁搜尋結果」，你【必須】在回答的適當位置，以 \`[參考連結](URL)\` 的格式自然地嵌入來源連結。
-    -   如果參考資料來源是「內部公告」，你【絕對不能】生成任何連結。
-5.  **最終回應:** 在你的主要回答內容之後，如果本次回答參考了內部公告，請務必在訊息的【最後】加上 \`[ANNOUNCEMENT_CARD:id1,id2,...]\` 這樣的標籤，其中 id 是你參考的公告 ID。
-6.  **嚴禁事項:**
-    -   【絕對禁止】輸出任何非指定格式的 JSON 程式碼或物件。
-    -   如果「# 參考資料」為空或與問題無關，就直接回答：「抱歉，關於您提出的問題，我目前找不到相關的資訊。」
-
-# 服務範圍限制
-你的知識範圍【嚴格限定】在「獎學金申請」相關事務。若問題無關，請禮貌地說明你的服務範圍並拒絕回答。`
-
 const ChatInterface = () => {
   const { user } = useAuth()
   const [messages, setMessages] = useState([])
@@ -424,17 +375,9 @@ const ChatInterface = () => {
       }
 
       const data = await response.json()
-      
-      // 處理 API 回應
-      let aiContent = ''
-      
-      if (data.structured_response) {
-        // 處理結構化回應
-        aiContent = data.response || '我收到了您的問題，正在處理中...'
-      } else {
-        // 處理普通回應
-        aiContent = data.response || '抱歉，我遇到了一些問題。請稍後再試。'
-      }
+
+      // 取得 AI 回應文字
+      const aiContent = data.response || '抱歉，我遇到了一些問題。請稍後再試。'
 
       const aiMessage = {
         role: 'assistant',

--- a/test-ai-response.md
+++ b/test-ai-response.md
@@ -2,18 +2,9 @@
 
 ## 主要改進項目
 
-### 1. JSON Output 格式統一 - 使用 Gemini 2.5 Flash responseSchema 方法
-- ✅ API 回應現在使用 Gemini 2.5 Flash 的 responseSchema，參考 `AI_ANALYSIS_METHODS.md`
-- ✅ 定義完整的 `chatResponseSchema` 包含：
-  - `answer_type`: 回答類型分類
-  - `content.sections`: 結構化內容段落
-  - `referenced_announcements`: 參考公告ID
-  - `source_type`: 資料來源類型
-  - `confidence_level`: 回答可信度
-  - `follow_up_suggestions`: 後續建議問題
-- ✅ 支援多種內容類型：text, list, table, highlight_important, highlight_deadline, source_link, contact_info
-- ✅ 使用 `generateStructuredAIResponse()` 函數調用 Gemini API
-- ✅ 自動回退到模擬回應（當 API 不可用時）
+### 1. 移除 JSON Output，改用純 Markdown 回應
+- ✅ API 不再要求結構化 JSON 格式
+- ✅ 前後端直接以文字或 Markdown 顯示內容
 
 ### 2. 修正 React Component 錯誤
 - ✅ 修正 `/ai-assistant/layout.jsx` 空檔案問題
@@ -45,7 +36,6 @@
 - ✅ 快捷問題區域（當對話較少時顯示）
 - ✅ 改進的操作按鈕佈局
 - ✅ 更好的載入狀態指示
-- ✅ 結構化的 AI 回應分類
 - ✅ 智能的後續問題建議
 
 ### 7. 輕量化介面設計改進 (2025/8/2 更新)
@@ -59,44 +49,11 @@
 - ✅ 整體採用灰白色調，營造輕鬆專業的視覺感受
 - ✅ 大幅減少視覺噪音，提升使用體驗
 
-## API Schema 結構
-
-### Chat Response Schema
-```javascript
-{
-  answer_type: "scholarship_info" | "application_guide" | "document_requirements" | "eligibility_criteria" | "contact_info" | "general_help" | "rejection",
-  content: {
-    sections: [
-      {
-        title: "段落標題",
-        content: [
-          {
-            type: "text" | "list" | "table" | "highlight_important" | "highlight_deadline" | "source_link" | "contact_info",
-            text?: "文字內容",
-            items?: ["列表項目"],
-            table_data?: [["表格", "資料"]],
-            link_url?: "連結網址",
-            link_text?: "連結文字",
-            deadline?: "截止日期",
-            amount?: "金額資訊"
-          }
-        ]
-      }
-    ]
-  },
-  referenced_announcements?: [1, 2, 3],
-  source_type: "internal" | "external" | "none",
-  confidence_level: "high" | "medium" | "low",
-  follow_up_suggestions?: ["後續建議問題"]
-}
-```
-
 ## 測試建議
 
 1. **Gemini API 測試**
    - 設定 `NEXT_PUBLIC_GOOGLE_AI_API_KEY` 環境變數
-   - 測試結構化回應的生成
-   - 驗證 JSON Schema 的正確性
+   - 驗證 AI 回應是否正常生成
 
 2. **桌面端測試**  
    - 檢查聊天介面的佈局和功能
@@ -110,15 +67,12 @@
    - 驗證快捷按鈕的大小是否適當
 
 4. **功能測試**
-   - 測試結構化回應的顯示
    - 檢查公告卡片的渲染
    - 驗證清除記錄和支援請求功能
    - 測試不同類型的 AI 回應
 
 ## API 變更
-- `/api/chat/route.js` 現在使用 Gemini 2.5 Flash 的 responseSchema
-- 新增 `generateStructuredAIResponse()` 函數
-- 新增 `generateMockStructuredResponse()` 作為備援
+- `/api/chat/route.js` 移除結構化 JSON 回應，改以純文字呈現
 - 改進的錯誤處理和自動回退機制
 - 支援多種回應類型和內容格式
 
@@ -135,4 +89,4 @@
 NEXT_PUBLIC_GOOGLE_AI_API_KEY=your_gemini_api_key_here
 ```
 
-這些改進使聊天介面更加現代化、響應式，並提供更順暢的使用者體驗，同時整合了 Gemini 2.5 Flash 的先進 JSON Schema 功能。
+這些改進使聊天介面更加現代化、響應式，並提供更順暢的使用者體驗。


### PR DESCRIPTION
## Summary
- 移除 ChatInterface 中的 JSON 回應判斷，直接顯示文字內容
- 調整 `/api/chat` 回應格式，不再輸出 `structured_response`
- 更新測試說明文件，改述為純 Markdown 回應

## Testing
- `npm run build` *(失敗：無法下載字型 Noto Sans TC)*

------
https://chatgpt.com/codex/tasks/task_e_688f5c8027088323927190cae495c15b